### PR TITLE
Changed FITS binary table file extension and added option to save pre…

### DIFF
--- a/config.py
+++ b/config.py
@@ -28,6 +28,7 @@ params['ut']                    = None
 params['gunzip']                = False
 params['out_dir']               = './nsdrp_out'       # used only in command line mode
 #params['serialize_rds']         = False
+params['jpg']                   = False     # if True then write preview plots in JPG not PNG
 
 # configuration and tuning parameters
 params['max_n_flats']           = 8

--- a/nsdrp.py
+++ b/nsdrp.py
@@ -15,7 +15,7 @@ import nsdrp_koa
 #from DrpException import DrpException
 #import FlatCacher
 
-VERSION = '0.9.14'
+VERSION = '0.9.15'
 
 warnings.filterwarnings('ignore', category=UserWarning, append=True)
 
@@ -67,22 +67,23 @@ def main():
     config.params['spatial_jump_override'] = args.spatial_jump_override
     if args.out_dir is not None:
         config.params['out_dir'] = args.out_dir
+    config.params['jpg'] = args.jpg
 
     # initialize environment, setup main logger, check directories
-    #   try:
-    if config.params['cmnd_line_mode'] is True:
-        init(config.params['out_dir'])
-        nsdrp_cmnd.process_frame(args.arg1, args.arg2, args.b, config.params['out_dir'])
-    else:
-        init(args.arg2, args.arg1)
-        nsdrp_koa.process_dir(args.arg1, args.arg2)
-#     except Exception as e:
-#         print('ERROR: ' + e.message)
-#         if config.params['debug'] is True:
-#             exc_type, exc_value, exc_traceback = sys.exc_info()
-#             traceback.print_tb(exc_traceback, limit=1, file=sys.stdout)
-#             traceback.print_exception(exc_type, exc_value, exc_traceback, limit=2, file=sys.stdout)
-#         sys.exit(2)    
+    try:
+        if config.params['cmnd_line_mode'] is True:
+            init(config.params['out_dir'])
+            nsdrp_cmnd.process_frame(args.arg1, args.arg2, args.b, config.params['out_dir'])
+        else:
+            init(args.arg2, args.arg1)
+            nsdrp_koa.process_dir(args.arg1, args.arg2)
+    except Exception as e:
+        print('ERROR: ' + e.message)
+        if config.params['debug'] is True:
+            exc_type, exc_value, exc_traceback = sys.exc_info()
+            traceback.print_tb(exc_traceback, limit=1, file=sys.stdout)
+            traceback.print_exception(exc_type, exc_value, exc_traceback, limit=2, file=sys.stdout)
+        sys.exit(2)    
 
     sys.exit(0)
     
@@ -246,6 +247,8 @@ def parse_cmnd_line_args():
             help='output directory in command line mode [.], ignored in KOA mode')
     parser.add_argument('-b',
             help='filename of frame B in AB pair')
+    parser.add_argument('-jpg', help='store preview plots in JPG format instead of PNG',
+            action='store_true')
 
     return(parser.parse_args())
           

--- a/products.py
+++ b/products.py
@@ -7,6 +7,7 @@ import logging
 import os
 import errno
 import warnings
+import Image
 import numpy as np
 from astropy.io import fits
 from skimage import exposure
@@ -31,28 +32,28 @@ savePlots = True
 showPlots = False
 saveJpgs = False
 
-# This dictionary maps data product filename suffix (e.g. flux.tbl)
+# This dictionary maps data product filename suffix (e.g. flux_tbl.fits)
 # to output subdirectory (e.g. fitstbl/flux).
 subdirs = dict([
-                ('flux.tbl',        'fitstbl/flux'      ),
-                ('flux.txt',        'ascii/flux'        ),
-                ('flux.fits',       'fits/flux'         ),
-                ('flux.png',        'previews/flux'     ),
-                ('profile.tbl',     'fitstbl/profile'   ),
-                ('profile.txt',     'ascii/profile'     ),
-                ('profile.fits',    'fits/profile'      ),
-                ('profile.png',     'previews/profile'  ),
-                ('calids.tbl',      'fitstbl/cal'       ),
-                ('calids.txt',      'ascii/cal'         ),
-                ('order.fits',      'fits/order'        ),
-                ('order.png',       'previews/order'    ),
-                ('sky.fits',        'fits/sky'          ),
-                ('sky.png',         'previews/sky'      ),
-                ('snr.fits',        'fits/snr'          ),
-                ('snr.png',         'previews/snr'      ),
-                ('trace.fits',      'fits/trace'        ),
-                ('trace.png',       'previews/trace'    ),
-#                 ('spectra.png',     'previews/spectra'  ),
+                ('flux_tbl.fits',       'fitstbl/flux'      ),
+                ('flux.txt',            'ascii/flux'        ),
+                ('flux.fits',           'fits/flux'         ),
+                ('flux.png',            'previews/flux'     ),
+                ('profile_tbl.fits',    'fitstbl/profile'   ),
+                ('profile.txt',         'ascii/profile'     ),
+                ('profile.fits',        'fits/profile'      ),
+                ('profile.png',         'previews/profile'  ),
+                ('calids_tbl.fits',     'fitstbl/cal'       ),
+                ('calids.txt',          'ascii/cal'         ),
+                ('order.fits',          'fits/order'        ),
+                ('order.png',           'previews/order'    ),
+                ('sky.fits',            'fits/sky'          ),
+                ('sky.png',             'previews/sky'      ),
+                ('snr.fits',            'fits/snr'          ),
+                ('snr.png',             'previews/snr'      ),
+                ('trace.fits',          'fits/trace'        ),
+                ('trace.png',           'previews/trace'    ),
+#               ('spectra.png',     'previews/spectra'  ),
                ])
 
 
@@ -62,7 +63,7 @@ def constructFileName(outpath, base_name, order, fn_suffix):
     outpath - data product root directory path
     base_name - base object file name, e.g. NS.20000325.49894
     order - order number, or None if this is not a per-order file
-    fn_suffix - filename suffix, e.g. flux.tbl
+    fn_suffix - filename suffix, e.g. flux_tbl.fits
     """
     fn = outpath + '/' + subdirs[fn_suffix] + '/' + base_name + '_' + fn_suffix
     if order is None:
@@ -330,7 +331,7 @@ def tracePlot(outpath, base_name, order_num, raw, fit, mask):
     pl.legend(loc='best', prop={'size': 8})
 
     fn = constructFileName(outpath, base_name, order_num, 'trace.png')
-    pl.savefig(fn)
+    savePreviewPlot(fn)
     pl.close()
     log_fn(fn)
     
@@ -435,7 +436,7 @@ def profileFitsTable(outpath, base_name, order_num, profile):
             fits.Column(name='row (pix)', format='1I', array=np.arange(profile.shape[0], dtype=int)),
             fits.Column(name='mean_flux (cnts)', format='1D', array=profile)]))
     thdulist = fits.HDUList([prihdu, tbhdu]) 
-    fn = constructFileName(outpath, base_name, order_num, 'profile.tbl')
+    fn = constructFileName(outpath, base_name, order_num, 'profile_tbl.fits')
     thdulist.writeto(fn, clobber=True)  
     log_fn(fn)
     return  
@@ -545,7 +546,7 @@ def profilePlot(outpath, base_name, order_num, profile, peak, centroid,
     pl.legend(loc='best', prop={'size': 8})
     
     fn = constructFileName(outpath, base_name, order_num, 'profile.png')
-    pl.savefig(fn)
+    savePreviewPlot(fn)
     pl.close()
     log_fn(fn)
     return
@@ -635,7 +636,7 @@ def fluxFitsTable(outpath, base_name, order_num, wave, flux, sky, synth_sky, err
                 fits.Column(name='trace_mean (pix)', format='1D', array=trace_mean),
                 fits.Column(name='trace_fit (pix)', format='1D', array=trace_fit),
                 fits.Column(name='fit_res (pix)', format='1D', array=trace_mean - trace_fit)])
-    fn = constructFileName(outpath, base_name, order_num, 'flux.tbl')   
+    fn = constructFileName(outpath, base_name, order_num, 'flux_tbl.fits')   
     tbhdu.writeto(fn, clobber=True)
     log_fn(fn)
     return
@@ -662,7 +663,7 @@ def spectrumPlot(outpath, base_name, title, order_num, y_units, cont, wave,
     #axes.set_ylim(0, 300)
     
     fn = constructFileName(outpath, base_name, order_num, title + '.png')
-    pl.savefig(fn)
+    savePreviewPlot(fn)
     log_fn(fn)
     return
     
@@ -697,7 +698,7 @@ def multiSpectrumPlot(outpath, base_name, order, y_units, cont, sky, noise, wave
 
     fn = constructFileName(outpath, base_name, order, 'spectra.png')
         
-    pl.savefig(fn)
+    savePreviewPlot(fn)
     log_fn(fn)
     pl.close()
     return
@@ -782,7 +783,7 @@ def wavelengthCalFitsTable(outpath, base_name, order, col, source, wave_exp, wav
                 fits.Column(name='peak (counts)', format='1D', array=peak),
                 fits.Column(name='disp (Angstroms/pixel)', format='1D', array=slope)]))
     thdulist = fits.HDUList([prihdu, tbhdu]) 
-    fn = constructFileName(outpath, base_name, None, 'calids.tbl')   
+    fn = constructFileName(outpath, base_name, None, 'calids_tbl.fits')   
     thdulist.writeto(fn, clobber=True)         
     log_fn(fn)
     return
@@ -816,7 +817,7 @@ def twoDimOrderPlot(outpath, base_name, title, base_filename, order_num, data, x
 #     pl.set_cmap('Blues_r')
 
     fn = constructFileName(outpath, base_name, order_num, base_filename)
-    pl.savefig(fn)
+    savePreviewPlot(fn)
     log_fn(fn)
     pl.close()
         
@@ -833,5 +834,24 @@ def twoDimOrderFits(outpath, base_name, order_num, data, header):
     hdulist.writeto(fn, clobber=True)
     log_fn(fn)
     return
+
+
+def savePreviewPlot(fn):
+    """
+    Saves a preview plot in either PNG or JPG format, depending on configuration parameter.
+    
+    If config.params['jpg'] is false then the plot is saved in PNG format which is the default.
+    If config.params['jpg'] is true then the PNG file is converted to JPG format and the PNG file
+    is deleted.
+    
+    Args:
+        fn: filename for PNG format, e.g. out/previews/flux/KOAID.png
+        
+    """
+    pl.savefig(fn)
+    if (config.params['jpg']):
+        outfn = fn[:fn.find('.png')] + '.jpg'
+        Image.open(fn).save(outfn, 'JPEG')
+        os.remove(fn)
     
         


### PR DESCRIPTION
…view plots in JPG format

Changed FITS binary table file extensions from .tbl to .fits.  For example, profile.tbl is now profile_tbl.fits.

Added -jpg command line options which causes preview plots to be saved in JPG format rather than PNG format.