### PR TITLE
Cosmic ray cleaning on nod B now returns a tuple, needs unpacking

### DIFF
--- a/reduce_frame.py
+++ b/reduce_frame.py
@@ -68,7 +68,7 @@ def reduce_frame(raw, out_dir, flatCacher=None):
         logger.debug('cosmic ray cleaning object frame A complete')
         if reduced.isPair:
             logger.info('cosmic ray cleaning object frame B')
-            reduced.objImg['B'] = image_lib.cosmic_clean(reduced.objImg['B'])
+            reduced.objImg['B'], _ = image_lib.cosmic_clean(reduced.objImg['B'])
             logger.debug('cosmic ray cleaning object frame B complete')
         reduced.cosmicCleaned = True
         logger.info(cosmicMethod)


### PR DESCRIPTION
The recent changes to cosmic ray cleaning must have left out the tuple unpacking of nod B when run in commandline mode (as opposed to KOA mode).  This two character tweak fixes the unpacking issue so that the array broadcasting in the next step works.