### PR TITLE
Improved check for required modules routine

### DIFF
--- a/check_modules.py
+++ b/check_modules.py
@@ -15,7 +15,8 @@ MODULES = [
     'scipy',
     'argparse',
     'statsmodels',
-    'PIL']
+    'PIL',
+    'astroscrappy']
 
 missingModules = []
 

--- a/dgn.py
+++ b/dgn.py
@@ -11,7 +11,6 @@ from skimage import exposure
 import config
 
 import scipy.misc
-from scipy.misc.pilutil import imresize
 
 # import Order
 # import ReducedDataSet

--- a/gui.py
+++ b/gui.py
@@ -1,7 +1,14 @@
+import os
+import check_modules
+
+requiredModules = check_modules.is_missing()
+if requiredModules:
+    print(('Missing modules: ' + ', '.join(requiredModules)))
+    os.sys.exit()
+
 from datetime import datetime
 import threading
 import time
-import os
 import glob
 import fnmatch
 import subprocess as sp
@@ -9,14 +16,15 @@ from PIL import Image as imopen
 from PIL import ImageTk
 
 
+# Import tkinter for python 3 or Tkinter for python 2
 try:
     from tkinter import *
     from tkinter.filedialog import askopenfilename
     from tkinter.filedialog import askdirectory
 except ImportError:
-    from tkinter import *
-    from tkinter.filedialog import askopenfilename
-    from tkinter.filedialog import askdirectory
+    from Tkinter import *
+    from Tkinter.filedialog import askopenfilename
+    from Tkinter.filedialog import askdirectory
 
 
 class nsdrpGui():

--- a/nsdrp.py
+++ b/nsdrp.py
@@ -1,14 +1,14 @@
 import os
-import config
-import nsdrp_cmnd
-import nsdrp_koa
-
 import check_modules
+
 requiredModules = check_modules.is_missing()
 if requiredModules:
     print(('Missing modules: ' + ', '.join(requiredModules)))
     os.sys.exit()
 
+import config
+import nsdrp_cmnd
+import nsdrp_koa
 import argparse
 import logging
 from astropy.io import fits


### PR DESCRIPTION
- Added check to GUI and moved it to the beginning of nsdrp.py

- Added astroscrappy (fast cosmic ray rejection) to required modules

- Removed unused import of imresize (otherwise this will throw an error because it was deprecated in scipy v1.0.0 and will be removed in v1.3.0)